### PR TITLE
Centralize publications data for profile and publications page

### DIFF
--- a/_data/publications.yml
+++ b/_data/publications.yml
@@ -1,0 +1,96 @@
+# Single source of truth for all publications.
+# Add new entries here — profile pages and /publications/ render from this file.
+# Sort: newest first within each category.
+
+# ── 언론기고 ──────────────────────────────────────────────
+- title: "영국의 아주 오래된 양당제, 균열은 시작되었다"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=57889"
+  outlet: "시사IN"
+  date: 2026-05-01
+  category: media
+
+- title: "야권 지지층의 연합전선은 계속될까?"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=52805"
+  outlet: "시사IN"
+  date: 2024-04-15
+  category: media
+
+- title: "부동산 가격이 선거에 미치는 영향"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=52683"
+  outlet: "시사IN"
+  date: 2024-04-10
+  category: media
+
+- title: "데이터로 본 총선 1~9"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=52688"
+  outlet: "시사IN"
+  date: 2024-03-15
+  category: media
+
+- title: "상경하는 20대가 선호하는 동네도 바뀌었다"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=51540"
+  outlet: "시사IN"
+  date: 2023-11-01
+  category: media
+
+- title: "'혁신' 품은 도시 빈집도 잔뜩 품었다"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=40494"
+  outlet: "시사IN"
+  date: 2019-10-01
+  category: media
+
+- title: "양꼬치 성지엔 프랜차이즈가 없다"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=33874"
+  outlet: "시사IN"
+  date: 2019-02-01
+  category: media
+
+# ── 외부협업 (기획 및 데이터분석) ─────────────────────────
+- title: "제주 원도심에서 찾은 공유자전거 가능성"
+  url: "https://www.jejusori.net/news/articleView.html?idxno=326507"
+  outlet: "리빙랩"
+  date: 2019-01-01
+  category: collab
+
+- title: "서울시 민원 38.8%는 바로 이 문제"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=31596"
+  outlet: "서울시 응답소"
+  date: 2018-06-01
+  category: collab
+
+- title: "오늘 오후 2시, 어디에 계셨습니까?"
+  url: "https://www.sisain.co.kr/news/articleView.html?idxno=31381"
+  outlet: "서울시 생활인구"
+  date: 2018-05-01
+  category: collab
+
+- title: "대림동에서 보낸 서른 번의 밤"
+  url: "https://daerim.sisain.co.kr/"
+  outlet: "프랜차이즈"
+  date: 2017-06-01
+  category: collab
+
+- title: "소리없이 번지는 도시의 질병 빈집"
+  url: "https://house.sisain.co.kr/"
+  outlet: "공가"
+  date: 2017-03-01
+  category: collab
+
+- title: "'58년 개띠'의 상가 사냥, '94년 개띠'를 몰아내다"
+  url: "https://www.hani.co.kr/arti/economy/property/753898.html"
+  outlet: "젠트리피케이션"
+  date: 2016-08-01
+  category: collab
+
+# ── 강연 / 미디어 ─────────────────────────────────────────
+- title: "YTN라디오 김혜민의 Issue & 피플"
+  url: "https://www.youtube.com/watch?v=8folReYpmII&ab_channel=YTN%EB%9D%BC%EB%94%94%EC%98%A4"
+  outlet: "YTN라디오"
+  date: 2024-01-01
+  category: talk
+
+- title: "미디어의 미래 컨퍼런스 2021"
+  url: "https://www.mediafuture.kr/event/history/history-2021.html"
+  outlet: "미디어의 미래"
+  date: 2021-01-01
+  category: talk

--- a/_layouts/profile-en.html
+++ b/_layouts/profile-en.html
@@ -44,10 +44,10 @@ layout: default
   <div class="profile-section">
     <h2 class="profile-section-title">Recent Publications</h2>
     <ul class="profile-list">
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52805">야권 지지층의 연합전선은 계속될까?</a> <span class="text-muted">시사IN, 2024.04</span></li>
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52683">부동산 가격이 선거에 미치는 영향</a> <span class="text-muted">시사IN, 2024.04</span></li>
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52688">데이터로 본 총선 1~9</a> <span class="text-muted">시사IN, 2024.03</span></li>
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=57889">영국의 아주 오래된 양당제, 균열은 시작되었다</a> <span class="text-muted">시사IN, 2026.05</span></li>
+      {% assign sorted_pubs = site.data.publications | sort: "date" | reverse %}
+      {% for pub in sorted_pubs limit: 3 %}
+        <li><a href="{{ pub.url }}">{{ pub.title }}</a> <span class="text-muted">{{ pub.outlet }}, {{ pub.date | date: "%Y.%m" }}</span></li>
+      {% endfor %}
     </ul>
     <a href="/publications/" class="profile-see-all">See all &rarr;</a>
   </div>

--- a/_layouts/profile.html
+++ b/_layouts/profile.html
@@ -42,9 +42,10 @@ layout: default
   <div class="profile-section">
     <h2 class="profile-section-title">Recent Publications</h2>
     <ul class="profile-list">
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52805">야권 지지층의 연합전선은 계속될까?</a> <span class="text-muted">시사IN, 2024.04</span></li>
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52683">부동산 가격이 선거에 미치는 영향</a> <span class="text-muted">시사IN, 2024.04</span></li>
-      <li><a href="https://www.sisain.co.kr/news/articleView.html?idxno=52688">데이터로 본 총선 1~9</a> <span class="text-muted">시사IN, 2024.03</span></li>
+      {% assign sorted_pubs = site.data.publications | sort: "date" | reverse %}
+      {% for pub in sorted_pubs limit: 3 %}
+        <li><a href="{{ pub.url }}">{{ pub.title }}</a> <span class="text-muted">{{ pub.outlet }}, {{ pub.date | date: "%Y.%m" }}</span></li>
+      {% endfor %}
     </ul>
     <a href="/publications/" class="profile-see-all">See all &rarr;</a>
   </div>

--- a/_tabs/publications.md
+++ b/_tabs/publications.md
@@ -4,25 +4,24 @@ icon: fas fa-pen-nib
 order: 2
 ---
 
+{% assign media_pubs = site.data.publications | where: "category", "media" | sort: "date" | reverse %}
+{% assign collab_pubs = site.data.publications | where: "category", "collab" | sort: "date" | reverse %}
+{% assign talk_pubs = site.data.publications | where: "category", "talk" | sort: "date" | reverse %}
+
 ## 언론기고
 
-- [야권 지지층의 연합전선은 계속될까?](https://www.sisain.co.kr/news/articleView.html?idxno=52805) — 시사IN, 2024.04
-- [부동산 가격이 선거에 미치는 영향](https://www.sisain.co.kr/news/articleView.html?idxno=52683) — 시사IN, 2024.04
-- [데이터로 본 총선 1~9](https://www.sisain.co.kr/news/articleView.html?idxno=52688) — 시사IN, 2024.03
-- [상경하는 20대가 선호하는 동네도 바뀌었다](https://www.sisain.co.kr/news/articleView.html?idxno=51540) — 시사IN, 2023.11
-- ['혁신' 품은 도시 빈집도 잔뜩 품었다](https://www.sisain.co.kr/news/articleView.html?idxno=40494) — 시사IN, 2019.10
-- [양꼬치 성지엔 프랜차이즈가 없다](https://www.sisain.co.kr/news/articleView.html?idxno=33874) — 시사IN, 2019.02
+{% for pub in media_pubs %}
+- [{{ pub.title }}]({{ pub.url }}) — {{ pub.outlet }}, {{ pub.date | date: "%Y.%m" }}
+{% endfor %}
 
 ## 외부협업 (기획 및 데이터분석)
 
-- [제주 원도심에서 찾은 공유자전거 가능성](https://www.jejusori.net/news/articleView.html?idxno=326507) — 리빙랩
-- [서울시 민원 38.8%는 바로 이 문제](https://www.sisain.co.kr/news/articleView.html?idxno=31596) — 서울시 응답소
-- [오늘 오후 2시, 어디에 계셨습니까?](https://www.sisain.co.kr/news/articleView.html?idxno=31381) — 서울시 생활인구
-- [대림동에서 보낸 서른 번의 밤](https://daerim.sisain.co.kr/) — 프랜차이즈
-- [소리없이 번지는 도시의 질병 빈집](https://house.sisain.co.kr/) — 공가
-- ['58년 개띠'의 상가 사냥, '94년 개띠'를 몰아내다](https://www.hani.co.kr/arti/economy/property/753898.html) — 젠트리피케이션
+{% for pub in collab_pubs %}
+- [{{ pub.title }}]({{ pub.url }}) — {{ pub.outlet }}
+{% endfor %}
 
 ## 강연 / 미디어
 
-- [YTN라디오 김혜민의 Issue & 피플](https://www.youtube.com/watch?v=8folReYpmII&ab_channel=YTN%EB%9D%BC%EB%94%94%EC%98%A4)
-- [미디어의 미래 컨퍼런스 2021](https://www.mediafuture.kr/event/history/history-2021.html)
+{% for pub in talk_pubs %}
+- [{{ pub.title }}]({{ pub.url }})
+{% endfor %}


### PR DESCRIPTION
## Summary
- Created `_data/publications.yml` as the single source of truth for all publications (media, collab, talks)
- Profile pages (EN/KR) now dynamically render the **top 3 most recent** publications from the data file, sorted newest-first
- `/publications/` tab renders all entries by category from the same data file
- Previously, publications were hardcoded separately in 3 files — edits required updating each one manually

## How it works
- Add/edit entries in `_data/publications.yml` → both profile "Recent Publications" and the full Publications page update automatically
- Each entry has: `title`, `url`, `outlet`, `date`, `category` (media/collab/talk)
- Profile pages show `limit: 3` sorted by `date | reverse`

## Test plan
- [ ] Verify EN profile (`/`) shows 3 latest publications, newest first
- [ ] Verify KR profile (`/ko/`) shows the same 3
- [ ] Verify `/publications/` page lists all entries grouped by category
- [ ] Add a test entry to `publications.yml` and confirm it appears on both pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)